### PR TITLE
fix missing version.txt issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     tests_require=[
     ],
     install_requires=open('requirements.txt').read(),
+    include_package_data=True,
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
Commit 792066517838643962e2214bf27a11f1201beb99 introduced a bug where the `setup.py` was configured to not include `djangotransifex/version.txt` when installed from pip.  This breaks when `__init__.py` goes to look for it.

Setting `include_package_data=True` ensures version.txt is included.