### PR TITLE
Django 1.8 Compatibility

### DIFF
--- a/djangotransifex/app_settings.py
+++ b/djangotransifex/app_settings.py
@@ -15,7 +15,7 @@ if TRANSIFEX_PASSWORD is None:
     ))
 
 
-TRANSIFEX_HOST = getattr(settings, 'TRANSIFEX_HOST', 'https://www.transifex.net/')
+TRANSIFEX_HOST = getattr(settings, 'TRANSIFEX_HOST', 'https://www.transifex.com/')
 SOURCE_LANGUAGE_CODE = getattr(settings, 'TRANSIFEX_SOURCE_LANGUAGE', settings.LANGUAGE_CODE)
 RESOURCE_PREFIX = getattr(settings, 'TRANSIFEX_RESOURCE_PREFIX', '')
 PROJECT_SLUG = getattr(settings, 'TRANSIFEX_PROJECT_SLUG', 'MyProject')

--- a/djangotransifex/management/commands/tx.py
+++ b/djangotransifex/management/commands/tx.py
@@ -22,6 +22,13 @@ class Command(BaseCommand):
     password = app_settings.TRANSIFEX_PASSWORD
     host = app_settings.TRANSIFEX_HOST
 
+    # This should probably be replaced in the future with an add_argument()
+    # method.  In this meantime, this gets us compatibility with Django 1.8.
+    # 
+    # https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/
+    #   #accepting-optional-arguments
+    args = 'command'
+
     @property
     def help(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django>=1.3,<1.6
+django>=1.3
 python-transifex==0.1.7
 
 # Test requirements


### PR DESCRIPTION
Django [switched argument parsers in 1.8](https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#accepting-optional-arguments) which broke this package.

This fix is good for another major version or two of Django, then we should probably switch to [their recommended technique for the future](https://docs.djangoproject.com/en/1.8/howto/custom-management-commands/#django.core.management.BaseCommand.add_arguments).
