### PR TITLE
Fixes and improvements for locale path determination (Issue #20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 dist/
 djangotransifex.egg-info/
 
+*.pyc
+
 # PyCharm editor files
 .idea

--- a/djangotransifex/api.py
+++ b/djangotransifex/api.py
@@ -8,9 +8,10 @@ from djangotransifex.exceptions import LanguageCodeNotAllowed, NoPoFilesFound, \
     ProjectNotFound, ResourceNotFound
 from django.conf import settings
 
+
 class DjangoTransifexAPI(TransifexAPI):
     
-    def upload_source_translations(self, project_slug):
+    def upload_source_translations(self, project_slug, locale_path=None):
         """
         Uploads the current translations as a new source translations. 
         
@@ -19,14 +20,14 @@ class DjangoTransifexAPI(TransifexAPI):
         
         @param project_slug
             the project slug
+        @param locale_path
+            the root path to the locale files
             
         @return 
         """
-
-
         source_folder = os.path.join(
-             app_settings.PROJECT_PATH, 'locale',
-             app_settings.SOURCE_LANGUAGE_CODE, 'LC_MESSAGES'
+            locale_path or app_settings.LOCALE_PATH,
+            app_settings.SOURCE_LANGUAGE_CODE, 'LC_MESSAGES'
         )
         files = [filepath for filepath in glob.glob(source_folder + '/*.po')]
         if len(files) == 0:
@@ -64,7 +65,7 @@ class DjangoTransifexAPI(TransifexAPI):
                     # Unknown exception
                     raise
                 
-    def upload_translations(self, project_slug, language_code):
+    def upload_translations(self, project_slug, language_code, locale_path=None):
         """
         Uploads the current translations for the given language to Transifex. 
         
@@ -76,7 +77,9 @@ class DjangoTransifexAPI(TransifexAPI):
         @param language_code
             The language code to upload. This should be the language code used
             in the Django project, not the code used on Transifex.
-            
+        @param locale_path
+            the root path to the locale files
+
         @return 
             None
             
@@ -95,7 +98,8 @@ class DjangoTransifexAPI(TransifexAPI):
             raise LanguageCodeNotAllowed(language_code)
         
         folder = os.path.join(
-             app_settings.PROJECT_PATH, 'locale', language_code, 'LC_MESSAGES'
+            locale_path or app_settings.LOCALE_PATH,
+            language_code, 'LC_MESSAGES'
         )
         files = [filepath for filepath in glob.glob(folder + '/*.po')]
         if len(files) == 0:
@@ -131,7 +135,7 @@ class DjangoTransifexAPI(TransifexAPI):
                     # Unknown exception
                     raise
                 
-    def pull_translations(self, project_slug, source_language):
+    def pull_translations(self, project_slug, source_language, locale_path=None):
         """
         Pull all translations from the remote Transifex server to the local
         machine, creating the folders where needed
@@ -141,7 +145,9 @@ class DjangoTransifexAPI(TransifexAPI):
         @param source_language
             The source language code.
             This should be the *Transifex* language code 
-        
+        @param locale_path
+            the root path to the locale files
+
         @return None
         
         @raises ProjectNotFound
@@ -167,8 +173,8 @@ class DjangoTransifexAPI(TransifexAPI):
                     transifex_language_code
                 )
                 pofile_dir = os.path.join(
-                    app_settings.PROJECT_PATH, 'locale', local_language_code,
-                    'LC_MESSAGES'
+                    locale_path or app_settings.LOCALE_PATH,
+                    local_language_code, 'LC_MESSAGES'
                 )
                 if not os.path.exists(pofile_dir):
                     os.makedirs(pofile_dir)

--- a/djangotransifex/app_settings.py
+++ b/djangotransifex/app_settings.py
@@ -26,15 +26,11 @@ PROJECT_SLUG = getattr(settings, 'TRANSIFEX_PROJECT_SLUG', 'MyProject')
 # the value should be a string corresponding to the Django code
 LANGUAGE_MAPPING = getattr(settings, 'TRANSIFEX_LANGUAGE_MAPPING', {})
 
-def _get_project_path():
-    from django.utils.importlib import import_module
-    import os
-    parts = settings.SETTINGS_MODULE.split('.')
-    project = import_module(parts[0])
-    projectpath = os.path.abspath(os.path.dirname(project.__file__))
-    return projectpath
+
+def _get_locale_path():
+    locale_path = getattr(settings, 'LOCALE_PATHS', tuple())
+    return locale_path[0] if locale_path else './locale'
+
 
 # Not strictly a setting, but this is a good place to keep it
-PROJECT_PATH = getattr(settings, 'TRANSIFEX_PROJECT_PATH',
-                       lazy(_get_project_path))
-
+LOCALE_PATH = getattr(settings, 'TRANSIFEX_LOCALE_PATH', _get_locale_path())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,12 +21,11 @@ def pytest_configure():
             'djangotransifex',
             'tests',
         ),
-        TRANSIFEX_USERNAME = 'abcde',
-        TRANSIFEX_PASSWORD = 'abcde',
-        TRANSIFEX_LANGUAGE_MAPPING = {'en_GB': 'en-gb', 'it_IT': 'it'},
-        LANGUAGE_CODE = 'en-gb',
-        LANGUAGES = (('en-gb', 'English'), ('it', 'Italian')),
-        TRANSIFEX_PROJECT_PATH = '.'
+        LANGUAGE_CODE='en-gb',
+        LANGUAGES=(('en-gb', 'English'), ('it', 'Italian')),
+        TRANSIFEX_USERNAME='abcde',
+        TRANSIFEX_PASSWORD='abcde',
+        TRANSIFEX_LANGUAGE_MAPPING={'en_GB': 'en-gb', 'it_IT': 'it'},
     )
 
     try:


### PR DESCRIPTION
Since the `PROJECT_PATH` app setting was not documented, and was only ever used to determine the location of the locale files, I have renamed this to LOCALE_PATH and removed one level of path concatenation in the API methods.

I removed the lazy function and used the Django LOCALE_PATHS settings to determine the value for LOCALE_PATH, defaulting back to the './locale' should the setting not be available (which in real world use will only be when testing outside of Django). I evaluate this setting directly on importing the `app_settings` module, as I don't see the performance issue that might have led to using the `lazy` function in the first place.

Finally, since it's possible that a Django project has multiple locale paths (hence LOCALE_PATHS being a tuple), and this new setting only taking the first entry, I added a command-line flag to the `tx` command to allow specifying the locale path root on the command line, e.g.
```
./manage.py tx upload_translations it --localepath /usr/local/my/shared/locale
```
This works for all API calls that touch the locale files.

Tests added. A bit of minor PEP8 cleanup in there too.